### PR TITLE
Only add location when it's present

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -121,10 +121,6 @@ function addEvent(event) {
  * Maps the JSON for an event from our API to an object usable by the ical lib.
  */
 function apiEventToFeedObject(event) {
-    var currentVenue = '';
-    if(event && event.links && event.links.venue && event.links.venue.linkage){
-        currentVenue = venueIdsToVenueAddresses[event.links.venue.linkage.id].address;
-    }
     var status = event.links.status && event.links.status.linkage && event.links.status.linkage.id;
     var prepend = '';
 
@@ -133,12 +129,17 @@ function apiEventToFeedObject(event) {
         prepend = '[Canceled] ';
     }
 
-    return {
+    var result = {
         start: new Date(event.startDateTime),
         end: new Date(event.endDateTime),
         summary: prepend + (event.shortTitle || event.title || ('Tech@NYU Event')),
         description: event.description || event.details,
-        url: event.rsvpUrl || '',
-        location: currentVenue,
+        url: event.rsvpUrl || ''
     };
+    
+    if(event.links && event.links.venue && event.links.venue.linkage){
+        result.location = venueIdsToVenueAddresses[event.links.venue.linkage.id].address;
+    }
+    
+    return result;
 }


### PR DESCRIPTION
@AbhiAgarwal sorry for opening this now. I was looking at your pr last night really quickly, and this didn't pop into my head until later. It's a pretty simple change.

Before, if there was no venue, we we're adding a location as an empty string; now, we leave location undefined on the result unless a venue with an address exists. 

I'm not sure if this actually makes a difference in the event output, or if the `ical` library is smart enough to not output a location field at all when the location is set as an empty string. But, either way, this seems more logically correct (and more robust against changes in the library's behavior).
